### PR TITLE
ping pong server - woot woot

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,30 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+# This configuration is loaded before any dependency and is restricted
+# to this project. If another project depends on this project, this
+# file won't be loaded nor affect the parent project. For this reason,
+# if you want to provide default values for your application for
+# 3rd-party users, it should be done in your "mix.exs" file.
+
+# You can configure for your application as:
+#
+#     config :gen_server_grok, key: :value
+#
+# And access this configuration in your application as:
+#
+#     Application.get_env(:gen_server_grok, :key)
+#
+# Or configure a 3rd-party app:
+#
+#     config :logger, level: :info
+#
+
+# It is also possible to import configuration files, relative to this
+# directory. For example, you can emulate configuration per environment
+# by uncommenting the line below and defining dev.exs, test.exs and such.
+# Configuration from the imported file will override the ones defined
+# here (which is why it is important to import them last).
+#
+#     import_config "#{Mix.env}.exs"

--- a/lib/gen_server_grok.ex
+++ b/lib/gen_server_grok.ex
@@ -1,0 +1,35 @@
+defmodule GenServerGrok do
+  require Logger
+  use GenServer
+
+  # CLIENT
+  # ======
+  def start_link do
+    GenServer.start_link(__MODULE__, :ok)
+  end
+
+  def ping(server) do
+    GenServer.call(server, {:ping})
+  end
+
+  def get_count(server) do
+    GenServer.call(server, {:count})
+  end
+
+  # SERVER
+  # ======
+  def init(:ok) do
+    init_state = %{count: 0}
+    {:ok, init_state}
+  end
+
+  def handle_call({:ping}, _from, state) do
+    response = {:pong}
+    new_state = %{state | count: state[:count] + 1 }
+    {:reply, {:ok, response}, new_state}
+  end
+
+  def handle_call({:count}, _from, state) do
+    {:reply, {:count, state[:count]}, state}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,32 @@
+defmodule GenServerGrok.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :gen_server_grok,
+     version: "0.0.1",
+     elixir: "~> 1.2",
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     deps: deps]
+  end
+
+  # Configuration for the OTP application
+  #
+  # Type "mix help compile.app" for more information
+  def application do
+    [applications: [:logger]]
+  end
+
+  # Dependencies can be Hex packages:
+  #
+  #   {:mydep, "~> 0.3.0"}
+  #
+  # Or git/path repositories:
+  #
+  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
+  #
+  # Type "mix help deps" for more examples and options
+  defp deps do
+    []
+  end
+end

--- a/test/ping_pong_grok_test.exs
+++ b/test/ping_pong_grok_test.exs
@@ -1,0 +1,8 @@
+defmodule GenServerGrokTest do
+  use ExUnit.Case
+  doctest GenServerGrok
+
+  test "the truth" do
+    assert 1 + 1 == 2
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## Dump:
- Went over language basics from Elixir official guide
- Pattern matching
- GenServer
- import vs require vs use
  - funny that we could compile even though we got rid of `start_link` in a GenServer module.. look into it
- Similarities with Ruby: atoms/symbols, do/end blocks, module importing process
- Differences with Ruby: varying function definitions instead of conditional blocks used for control flow
- Pattern of using a head atom in a tuple for recognition of messages
